### PR TITLE
User Mailers and Email Confirmation 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   # Adds support for Capybara system testing and selenium driver
+  gem 'figaro'
   gem 'pry'
   gem 'rspec-rails'
   gem 'capybara', '~> 2.13'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,8 +20,13 @@ class SessionsController < ApplicationController
       user = User.find_by(email: safe_params[:email])
       respond_to do |format|
         if user && user.authenticate(safe_params[:password])
-          session[:user_id] = user.id
-          format.json {render json: user}
+          if user.email_confirmed
+            session[:user_id] = user.id
+            format.json {render json: user}
+          else
+            error = "Email Not Confirmed! Please confirm your email address to continue..."
+            format.json {render :json => {:errors => error}, :status => 401 }
+          end
         elsif user && !user.authenticate(safe_params[:password])
           error = 'Password/Email did not match. Please try again'
           format.json {render :json => {:errors => error}, :status => 401 }

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -1,0 +1,14 @@
+class SuggestionsController < ApplicationController
+
+  def send_suggestion
+    user = User.find(params[:user][:id])
+    mail = SuggestionMailer.send_suggestion(user, params[:email_body])
+    mail.deliver_now
+    render json: {:success => "Message sent"}, status: 204
+  end
+
+  def region_expansion
+    user = User.find(params[:user][:id])
+    mail = SuggestionMailer.send_expansion_request(user, params[:email_body])
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'carboncollective.devops@gmail.com'
   layout 'mailer'
 end

--- a/app/mailers/suggestion_mailer.rb
+++ b/app/mailers/suggestion_mailer.rb
@@ -1,0 +1,16 @@
+class SuggestionMailer < ApplicationMailer
+
+    def send_suggestion(user, body)
+        @suggestion = body
+        @user = user
+        mail(to: 'carboncollective.devops@gmail.com',
+             subject: "App Suggestion")
+    end
+
+    def send_expansion_request(user, body)
+      @body = body
+      @mail = user
+      mail(to: 'carboncollective.devops@gmail.com',
+            subject: "New Requested Area")
+
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,6 @@
+class UserMailer < ApplicationMailer
+  def registration(user)
+    @user = user
+    mail(:to => "#{user.first + ' ' + user.last} <#{user.email}>", :subject => "Registration Confirmation")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   validate :check_email_format
 
-  before_create :add_zeros
+  before_create :add_zeros, :add_confirm_token
 
 def self.create_with_omniauth(auth)
   uid = auth['uid']
@@ -72,6 +72,12 @@ def gas_bills
   self.houses.map{|h| h.heat_bills}.flatten
 end
 
+def email_activate
+  self.email_confirmed = true
+  self.confirm_token = nil
+  self.save!(:validate => false)
+end
+
 private
   def check_email_format
     return if errors.key?(:email)
@@ -91,6 +97,12 @@ private
     self.total_gas_savings = 0
     self.total_carbon_savings = 0
     self.total_pounds_logged = 0
+  end
+
+  def add_confirm_token
+    if self.confirm_token.blank?
+        self.confirm_token = SecureRandom.urlsafe_base64.to_s
+    end
   end
 
 end

--- a/app/views/suggestion_mailer/send_expansion_request.html.erb
+++ b/app/views/suggestion_mailer/send_expansion_request.html.erb
@@ -1,0 +1,17 @@
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1> Expansion Request</h1>
+    <h3>This email comes from <%= @user.first %>, at <%= @user.email %>:</h3>
+    <h2>
+      <%= @body%><br>
+    </h2>
+    <p>
+    </p>
+    <p>Thanks for joining and have a great day!</p>
+  </body>
+</html>

--- a/app/views/suggestion_mailer/send_suggestion.html.erb
+++ b/app/views/suggestion_mailer/send_suggestion.html.erb
@@ -1,0 +1,17 @@
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1> App Suggestion</h1>
+    <h3>This email comes from <%= @user.first %>, at <%= @user.email %>:</h3>
+    <h2>
+      <%= @suggestion%><br>
+    </h2>
+    <p>
+    </p>
+    <p>Thanks for joining and have a great day!</p>
+  </body>
+</html>

--- a/app/views/user_mailer/registration.html.erb
+++ b/app/views/user_mailer/registration.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1> Hi <%= @user.first %>,</h1>
+    <h3>Thanks for registering! To confirm your registration click the URL below.</h3>
+    <%= confirm_email_users_url(@user.confirm_token) %>
+  </body>
+</html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,8 +29,19 @@ Rails.application.configure do
   end
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options = { :host => "http://localhost:3000" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :enable_starttls_auto => true,
+    :address        => "smtp.gmail.com",
+    :port           => 587,
+    :domain         => "gmail.com",
+    :user_name      => ENV['GMAIL_ACCT'],
+    :password       => ENV['GMAIL_PASSWORD'],
+    :authentication => :plain
+  }
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,9 +8,14 @@ Rails.application.routes.draw do
   resources :water_bills, only: [:create]
   resources :gas_bills, only: [:create]
   resources :users, only: [:create, :update]
+  resource :users do
+    member do
+      get :confirm_email
+    end
+  end
   resources :addresses, only: [:create]
   resources :houses, only: [:create]
-
+  post '/suggestions', to: 'suggestions#send_suggestion'
   namespace :api do
     namespace :v1 do
       resources :addresses, only: [:index, :show]

--- a/db/migrate/20180523200523_add_email_confirmation_columns_to_users.rb
+++ b/db/migrate/20180523200523_add_email_confirmation_columns_to_users.rb
@@ -1,0 +1,6 @@
+class AddEmailConfirmationColumnsToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :email_confirmed, :boolean
+    add_column :users, :confirm_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180521024429) do
+ActiveRecord::Schema.define(version: 20180523200523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -365,6 +365,8 @@ ActiveRecord::Schema.define(version: 20180521024429) do
     t.decimal "total_gas_savings"
     t.decimal "total_carbon_savings"
     t.decimal "total_pounds_logged"
+    t.boolean "email_confirmed"
+    t.string "confirm_token"
     t.index ["total_electricity_savings"], name: "index_users_on_total_electricity_savings"
     t.index ["total_gas_savings"], name: "index_users_on_total_gas_savings"
     t.index ["total_water_savings"], name: "index_users_on_total_water_savings"


### PR DESCRIPTION
adds user_mailer and suggestion_mailer; user_mailer fully functional …BE/FE and users are required to confirm their emails by clicking on a confirmation_link in an email sent by UserMailer::registration method, as of yet neither being performed as an ActiveJob nor asynchronously; Email should be styled; all hookups for mailers should be made for Heroku get first the mail working via production environ configs (then set up passwords in heroku password thing), then work on Redis/Background worker; Flashes after user signup could look nicer/have a 'Go to your email and click the link' splash page after first time signup that doesnt have LOGIN written right there; Suggestion mailers not used in frontend yet but are pending creation of email screen