### PR TITLE
Address save

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -7,9 +7,16 @@ class AddressesController < ApplicationController
     @address.zipcode_id = zipcode.id
     if @address.save
       render json: @address, status: 202
+    elsif !@address.save && @address.errors.messages[:address_line1][0] == 'has already been taken'
+      city_id = @address.city_id
+      address = @address.address_line1
+      old_address = Address.where(address_line1: address, city_id: city_id)[0]
+      @house = old_address.house
+      error = "House already exists"
+      render :json => {:errors => error, :house => @house.id}, status: 401
     else
       error = "Address did not save, please try again"
-      render :json => {errors: error}, status: 401
+      render :json => {:errors => error}, status: 401
     end
   end
 

--- a/app/controllers/api/v1/addresses_controller.rb
+++ b/app/controllers/api/v1/addresses_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::AddressesController < ApplicationController
 
   def show
     if Address.exists?(params[:id])
-      render json: Address.find(params[:id])
+      render json: Address.find(params[:id]), serializer: AddressBasicSerializer
     else
       render json: {error: "Address does not exist"}, status: 404
     end

--- a/app/controllers/api/v1/houses_controller.rb
+++ b/app/controllers/api/v1/houses_controller.rb
@@ -38,10 +38,8 @@ class Api::V1::HousesController < ApplicationController
     if User.exists?(params[:user_id]) && House.exists?(params[:id])
       house = House.find(params[:id])
       userhouse = UserHouse.where(user_id: params[:user_id], house: house.id)[0]
-      UserHouse.delete(userhouse.id)
-      house.no_residents -= 1
-      house.save
-      if house.no_residents == 0
+      UserHouse.destroy(userhouse.id)
+      if house.users.count == 0
         House.destroy(house.id)
       end
       render json: userhouse

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -58,6 +58,18 @@ class UsersController < ApplicationController
     end
   end
 
+  def old_houses
+    user = User.find(params[:user_id])
+    house = House.find(params[:house_id])
+    if user && house
+      user.houses << house
+      render json: user
+    else
+      error = "User could not be added to existing house"
+      render json: {errors: error}, status: 401
+    end
+  end
+
   private
 
     def authenticate_old_password(u, pass)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,11 +45,13 @@ class UsersController < ApplicationController
 
   def confirm_email
     user = User.find_by_confirm_token(params[:format])
+    # host = 'https://carbon-collective.github.io'
+    host = 'http://localhost:3001'
     if user
       user.email_activate
       flash[:success] = "Welcome to Carbon Collective! Your email has been confirmed.
       Please sign in to the app to continue."
-      redirect_to "http://localhost:3001/login-first-time"
+      redirect_to "#{host}/login-first-time"
     else
       flash[:error] = "Sorry. Page Invalid"
       render :file => 'public/404.html', :status => :not_found, :layout => false

--- a/app/models/user_house.rb
+++ b/app/models/user_house.rb
@@ -1,4 +1,19 @@
 class UserHouse < ApplicationRecord
   belongs_to :user
   belongs_to :house
+
+  before_create :update_house_no_residents_add
+  before_destroy :update_house_no_residents_less
+
+  def update_house_no_residents_add
+    house = House.find(self.house_id)
+    house.no_residents += 1
+    house.save
+  end
+
+  def update_house_no_residents_less
+    house = House.find(self.house_id)
+    house.no_residents -= 1
+    house.save
+  end
 end

--- a/app/serializers/address_basic_serializer.rb
+++ b/app/serializers/address_basic_serializer.rb
@@ -2,7 +2,7 @@ class AddressBasicSerializer < ActiveModel::Serializer
   attributes :id, :full_address
 
   def full_address
-    object.address_line1 + ' ' + object.address_line2 + ' ' + object.city.name +
+    object.address_line1 + ' ' + object.address_line2.to_s + ' ' + object.city.name +
         ', ' + object.region.name
   end
 end

--- a/app/serializers/address_basic_serializer.rb
+++ b/app/serializers/address_basic_serializer.rb
@@ -1,0 +1,8 @@
+class AddressBasicSerializer < ActiveModel::Serializer
+  attributes :id, :full_address
+
+  def full_address
+    object.address_line1 + ' ' + object.address_line2 + ' ' + object.city.name +
+        ', ' + object.region.name
+  end
+end

--- a/app/serializers/house_serializer.rb
+++ b/app/serializers/house_serializer.rb
@@ -1,6 +1,6 @@
 class HouseSerializer < ActiveModel::Serializer
   attributes :id, :total_sq_ft, :no_residents, :address, :neighborhood,
-                  :users_id, :users_names, :number_of_bills_entered,
+                  :users_names, :no_users, :number_of_bills_entered,
                   :total_electricity_consumption_to_date,
                   :total_electricity_savings_to_date,
                   :avg_total_electricity_consumption_per_resident,
@@ -26,8 +26,8 @@ class HouseSerializer < ActiveModel::Serializer
     }
   end
 
-  def users_id
-    object.users.map{|u| u.id}
+  def no_users
+    object.users.count
   end
 
   def users_names

--- a/app/serializers/house_serializer.rb
+++ b/app/serializers/house_serializer.rb
@@ -35,7 +35,10 @@ class HouseSerializer < ActiveModel::Serializer
   end
 
   def address
-    object.address
+    addy = object.address
+    addy.address_line1 + " #{addy.address_line2.to_s}" +
+        ', ' + addy.city.name + ', ' +
+          addy.region.name
   end
 
   def neighborhood

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :water_bills, only: [:create]
   resources :gas_bills, only: [:create]
   resources :users, only: [:create, :update]
+  post '/users/:user_id/old_houses/:house_id', to: 'users#old_houses'
   resource :users do
     member do
       get :confirm_email


### PR DESCRIPTION
Address creation now has a catch to check for houses that already exist in the database, and then require user to confirm. Backend changes include serializer update, changing routes for the house confirmation; Frontend changes which correlate with this merge are: Creation of a HouseExists page; requirement of confirmation in order to join an existing house + automatic re-route to dash from address creation page; Add_address, Add_household, and House_exist pages all have timers to sync with App; added the same on HouseSettings page for removal of house; updates to App index for authorization of pages; invention of house_id in sessionStorage to manage page authorization.