### PR TITLE
Apartment or house

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -12,8 +12,12 @@ class AddressesController < ApplicationController
       address = @address.address_line1
       old_address = Address.where(address_line1: address, city_id: city_id)[0]
       @house = old_address.house
-      error = "House already exists"
-      render :json => {:errors => error, :house => @house.id}, status: 401
+      if @house
+        error = "House already exists"
+        render :json => {:errors => error, :house => @house.id}, status: 401
+      else
+        render json: old_address, status: 202
+      end
     else
       error = "Address did not save, please try again"
       render :json => {:errors => error}, status: 401

--- a/app/controllers/api/v1/houses_controller.rb
+++ b/app/controllers/api/v1/houses_controller.rb
@@ -51,6 +51,6 @@ class Api::V1::HousesController < ApplicationController
 
   private
     def safe_params
-      params.require(:house).permit(:total_sq_ft, :no_residents, :address_id)
+      params.require(:house).permit(:total_sq_ft, :no_residents, :address_id, :apartment)
     end
 end

--- a/app/controllers/houses_controller.rb
+++ b/app/controllers/houses_controller.rb
@@ -14,6 +14,6 @@ class HousesController < ApplicationController
 
   private
      def safe_params
-        params.require(:house).permit(:total_sq_ft, :no_residents, :address_id)
+        params.require(:house).permit(:total_sq_ft, :no_residents, :address_id, :apartment)
      end
 end

--- a/app/models/house.rb
+++ b/app/models/house.rb
@@ -2,6 +2,7 @@ class House < ApplicationRecord
   include HouseHelper
 
   belongs_to :address
+
   validates_presence_of :total_sq_ft
   validates_presence_of :no_residents
 
@@ -18,5 +19,6 @@ class House < ApplicationRecord
   def bills
     self.electric_bills
   end
+
 
 end

--- a/app/models/user_house.rb
+++ b/app/models/user_house.rb
@@ -2,6 +2,8 @@ class UserHouse < ApplicationRecord
   belongs_to :user
   belongs_to :house
 
+  validates_uniqueness_of :user_id, :scope => :house_id
+
   before_create :update_house_no_residents_add
   before_destroy :update_house_no_residents_less
 

--- a/app/serializers/house_serializer.rb
+++ b/app/serializers/house_serializer.rb
@@ -1,6 +1,7 @@
 class HouseSerializer < ActiveModel::Serializer
   attributes :id, :total_sq_ft, :no_residents, :address, :neighborhood,
                   :users_names, :no_users, :number_of_bills_entered,
+                  :apartment,
                   :total_electricity_consumption_to_date,
                   :total_electricity_savings_to_date,
                   :avg_total_electricity_consumption_per_resident,

--- a/db/migrate/20180528023236_add_apt_toggle_to_houses.rb
+++ b/db/migrate/20180528023236_add_apt_toggle_to_houses.rb
@@ -1,0 +1,5 @@
+class AddAptToggleToHouses < ActiveRecord::Migration[5.1]
+  def change
+    add_column :houses, :apartment, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180523200523) do
+ActiveRecord::Schema.define(version: 20180528023236) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -204,6 +204,7 @@ ActiveRecord::Schema.define(version: 20180523200523) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "address_id"
+    t.boolean "apartment"
     t.index ["address_id"], name: "index_houses_on_address_id"
   end
 


### PR DESCRIPTION
Completes in house-creation form the feature of notifying whether a house is an apartment or not. Held on the House model as a boolean primitive. Also create a 404 page for more-thorough page rendering outside the given (authorized) routes.