### PR TITLE
No savings

### DIFF
--- a/app/controllers/api/v1/areas/city_carbon_controller.rb
+++ b/app/controllers/api/v1/areas/city_carbon_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::Areas::CityCarbonController < ApplicationController
   def users
     if City.exists?(params[:id])
       render json: City.find(params[:id])
-        .users.order(total_Carbon_savings: :desc)
+        .users.order(total_carbon_savings: :desc)
         .limit(10), each_serializer: UserCarbonSerializer
     else
       render json: {error: "City not in database. try again!"}, status: 404

--- a/app/controllers/api/v1/houses_controller.rb
+++ b/app/controllers/api/v1/houses_controller.rb
@@ -9,6 +9,7 @@ class Api::V1::HousesController < ApplicationController
       render json: House.find(params[:id]), serializer: HouseWaterSerializer if params[:resource] == 'water'
       render json: House.find(params[:id]), serializer: HouseGasSerializer if params[:resource] == 'gas'
       render json: House.find(params[:id]), serializer: HouseCarbonSerializer if params[:resource] == 'carbon'
+      render json: House.find(params[:id]), serializer: HouseElectricitySerializer if params[:resource] == nil
     else
       render json: {error: "House does not exist"}, status: 404
     end

--- a/app/helpers/user_carbon_helper.rb
+++ b/app/helpers/user_carbon_helper.rb
@@ -13,28 +13,28 @@ module UserCarbonHelper
   end
 
 # check
-  def household_total_carbon_savings
-    household ? household.total_carbon_savings_to_date : nil
+  def household_daily_carbon_consumption
+    household ? household.average_daily_carbon_consumption_per_resident : nil
   end
 
-  def neighborhood_total_carbon_savings
-    household.address.neighborhood ? household.address.neighborhood.total_carbon_saved : nil
+  def neighborhood_daily_carbon_consumption
+    household.address.neighborhood ? household.address.neighborhood.avg_daily_carbon_consumption : nil
   end
 
-  def city_total_carbon_savings
-    household ? household.address.city.total_carbon_saved : nil
+  def city_daily_carbon_consumption
+    household ? household.address.city.avg_daily_carbon_consumption : nil
   end
 
-  def county_total_carbon_savings
-    household ? household.address.county.total_carbon_saved : nil
+  def county_daily_carbon_consumption
+    household ? household.address.county.avg_daily_carbon_consumption : nil
   end
 
-  def region_total_carbon_savings
-    household ? household.address.city.region.total_carbon_saved : nil
+  def region_daily_carbon_consumption
+    household ? household.address.city.region.avg_daily_carbon_consumption : nil
   end
 
-  def country_total_carbon_savings
-    household ? household.address.city.region.country.total_carbon_saved : nil
+  def country_daily_carbon_consumption
+    household ? household.address.city.region.country.avg_daily_carbon_consumption : nil
   end
 
 end

--- a/app/helpers/user_carbon_helper.rb
+++ b/app/helpers/user_carbon_helper.rb
@@ -7,6 +7,7 @@ module UserCarbonHelper
     self.total_pounds_logged / user_date.to_i
   end
 
+  # big question marks around this method
   def avg_daily_carbon_consumption
     res_ = combine_average_use(self.avg_daily_electricity_consumption, self.avg_daily_gas_consumption)
     return res_.fdiv(self.total_electricitybill_days_logged) if res_ != 0

--- a/app/helpers/user_electricity_helper.rb
+++ b/app/helpers/user_electricity_helper.rb
@@ -11,28 +11,28 @@ module UserElectricityHelper
   end
 
 # check
-  def household_total_electricity_savings
-    household ? household.total_electricity_savings_to_date : nil
+  def household_daily_electricity_consumption
+    household ? household.average_daily_electricity_consumption_per_resident : nil
   end
 
-  def neighborhood_total_electricity_savings
-    household.address.neighborhood ? household.address.neighborhood.total_electricity_saved : nil
+  def neighborhood_daily_electricity_consumption
+    household.address.neighborhood ? household.address.neighborhood.avg_daily_electricity_consumed_per_user : nil
   end
 
-  def city_total_electricity_savings
-    household ? household.address.city.total_electricity_saved : nil
+  def city_daily_electricity_consumption
+    household ? household.address.city.avg_daily_electricity_consumed_per_user : nil
   end
 
-  def county_total_electricity_savings
-    household ? household.address.county.total_electricity_saved : nil
+  def county_daily_electricity_consumption
+    household ? household.address.county.avg_daily_electricity_consumed_per_user : nil
   end
 
-  def region_total_electricity_savings
-    household ? household.address.city.region.total_electricity_saved : nil
+  def region_daily_electricity_consumption
+    household ? household.address.city.region.avg_daily_electricity_consumed_per_user : nil
   end
 
-  def country_total_electricity_savings
-    household ? household.address.city.region.country.total_electricity_saved : nil
+  def country_daily_electricity_consumption
+    household ? household.address.city.region.country.avg_daily_electricity_consumed_per_user : nil
   end
 
 end

--- a/app/helpers/user_gas_helper.rb
+++ b/app/helpers/user_gas_helper.rb
@@ -10,28 +10,28 @@ module UserGasHelper
   end
 
 # check
-  def household_total_gas_savings
-    household ? household.total_gas_savings_to_date : nil
+  def household_daily_gas_consumption
+    household ? household.average_daily_gas_consumption_per_resident : nil
   end
 
-  def neighborhood_total_gas_savings
-    household.address.neighborhood ? household.address.neighborhood.total_gas_saved : nil
+  def neighborhood_daily_gas_consumption
+    household.address.neighborhood ? household.address.neighborhood.avg_daily_gas_consumed_per_user : nil
   end
 
-  def city_total_gas_savings
-    household ? household.address.city.total_gas_saved : nil
+  def city_daily_gas_consumption
+    household ? household.address.city.avg_daily_gas_consumed_per_user : nil
   end
 
-  def county_total_gas_savings
-    household ? household.address.county.total_gas_saved : nil
+  def county_daily_gas_consumption
+    household ? household.address.county.avg_daily_gas_consumed_per_user : nil
   end
 
-  def region_total_gas_savings
-    household ? household.address.city.region.total_gas_saved : nil
+  def region_daily_gas_consumption
+    household ? household.address.city.region.avg_daily_gas_consumed_per_user : nil
   end
 
-  def country_total_gas_savings
-    household ? household.address.city.region.country.total_gas_saved : nil
+  def country_daily_gas_consumption
+    household ? household.address.city.region.country.avg_daily_gas_consumed_per_user : nil
   end
 
 end

--- a/app/helpers/user_water_helper.rb
+++ b/app/helpers/user_water_helper.rb
@@ -10,28 +10,27 @@ module UserWaterHelper
   end
 
 # check
-  def household_total_water_savings
-    household ? household.total_water_savings_to_date : nil
+  def household_daily_water_consumption
+    household ? household.average_daily_water_consumption_per_resident : nil
   end
 
-  def neighborhood_total_water_savings
-    household.address.neighborhood ? household.address.neighborhood.total_water_saved : nil
+  def neighborhood_daily_water_consumption
+    household.address.neighborhood ? household.address.neighborhood.avg_daily_water_consumed_per_user : nil
   end
 
-  def city_total_water_savings
-    household ? household.address.city.total_water_saved : nil
+  def city_daily_water_consumption
+    household ? household.address.city.avg_daily_water_consumed_per_user : nil
   end
 
-  def county_total_water_savings
-    household ? household.address.county.total_water_saved : nil
+  def county_daily_water_consumption
+    household ? household.address.county.avg_daily_water_consumed_per_user : nil
   end
 
-  def region_total_water_savings
-    household ? household.address.city.region.total_water_saved : nil
+  def region_daily_water_consumption
+    household ? household.address.city.region.avg_daily_water_consumed_per_user : nil
   end
 
-  def country_total_water_savings
-    household ? household.address.city.region.country.total_water_saved : nil
+  def country_daily_water_consumption
+    household ? household.address.city.region.country.avg_daily_water_consumed_per_user : nil
   end
-
 end

--- a/app/serializers/electric_bill_serializer.rb
+++ b/app/serializers/electric_bill_serializer.rb
@@ -12,7 +12,7 @@ class ElectricBillSerializer < ActiveModel::Serializer
     object.electricity_saved.round(2).to_s + ' kwhs'
   end
   def carbon_impact
-    kwhs_to_carbon(object.electricity_saved).round(3).to_s + " lbs co2"
+    kwhs_to_carbon(object.total_kwhs).round(2).to_s + " lbs co2"
   end
   def house_info
     object.house

--- a/app/serializers/heat_bill_serializer.rb
+++ b/app/serializers/heat_bill_serializer.rb
@@ -12,7 +12,7 @@ class HeatBillSerializer < ActiveModel::Serializer
     object.gas_saved.round(2).to_s + ' therms'
   end
   def carbon_impact
-    therms_to_carbon(object.gas_saved).round(3).to_s + " lbs co2"
+    therms_to_carbon(object.total_therms).round(2).to_s + " lbs co2"
   end
   def house_info
     object.house

--- a/app/serializers/user_carbon_serializer.rb
+++ b/app/serializers/user_carbon_serializer.rb
@@ -2,12 +2,12 @@ class UserCarbonSerializer < ActiveModel::Serializer
   attributes :id, :first, :last, :avatar_url, :global_collective_savings,
                   :personal_savings_to_date,
                   :household, :neighborhood, :city, :county, :region, :country,
-                  :household_total_savings, :neighborhood_total_savings,
-                  :city_total_savings, :county_total_savings, :region_total_savings,
-                  :country_total_savings, :total_savings,
+                  :household_daily_consumption, :neighborhood_daily_consumption,
+                  :city_daily_consumption, :county_daily_consumption, :region_daily_consumption,
+                  :country_daily_consumption, :avg_daily_consumption,
                   :metric_sym,
 
-  def total_savings
+  def avg_daily_consumption
     object.total_carbon_savings.to_f.round(2).to_s + " lbs"
   end
   def neighborhood
@@ -38,28 +38,28 @@ class UserCarbonSerializer < ActiveModel::Serializer
     Global.first.total_carbon_saved.to_f.round(2).to_s + " lbs"
   end
 
-  def household_total_savings
+  def household_daily_consumption
     object.household.total_carbon_savings_to_date.round(3) if !object.houses.empty?
   end
 
-  def neighborhood_total_savings
-    object.neighborhood.carbon_ranking.total_carbon_saved.round(3) if !object.houses.empty?
+  def neighborhood_daily_consumption
+    object.neighborhood.carbon_ranking.avg_daily_carbon_consumed_per_user.round(3) if !object.houses.empty?
   end
 
-  def city_total_savings
-    object.city.carbon_ranking.total_carbon_saved.round(3) if !object.houses.empty?
+  def city_daily_consumption
+    object.city.carbon_ranking.avg_daily_carbon_consumed_per_user.round(3) if !object.houses.empty?
   end
 
-  def county_total_savings
-    object.county.carbon_ranking.total_carbon_saved.round(3) if !object.houses.empty?
+  def county_daily_consumption
+    object.county.carbon_ranking.avg_daily_carbon_consumed_per_user.round(3) if !object.houses.empty?
   end
 
-  def region_total_savings
-    object.region.carbon_ranking.total_carbon_saved.round(3) if !object.houses.empty?
+  def region_daily_consumption
+    object.region.carbon_ranking.avg_daily_carbon_consumed_per_user.round(3) if !object.houses.empty?
   end
 
-  def country_total_savings
-    object.country.carbon_ranking.total_carbon_saved.round(3) if !object.houses.empty?
+  def country_daily_consumption
+    object.country.carbon_ranking.avg_daily_carbon_consumed_per_user.round(3) if !object.houses.empty?
   end
   def metric_sym
     'lbsCO2'

--- a/app/serializers/user_electricity_serializer.rb
+++ b/app/serializers/user_electricity_serializer.rb
@@ -1,16 +1,16 @@
 class UserElectricitySerializer < ActiveModel::Serializer
-  attributes :id, :total_savings, :first, :last, :email,
+  attributes :id, :avg_daily_consumption, :first, :last, :email,
                   :avatar_url, :house_ids,
                   :rank, :arrow, :last_updated,
                   :personal_savings_to_date,
                   :global_collective_savings,
                   :household, :neighborhood, :city, :county, :region, :country,
-                  :household_total_savings,
-                  :neighborhood_total_savings,
-                  :city_total_savings,
-                  :county_total_savings,
-                  :region_total_savings,
-                  :country_total_savings,
+                  :household_daily_consumption,
+                  :neighborhood_daily_consumption,
+                  :city_daily_consumption,
+                  :county_daily_consumption,
+                  :region_daily_consumption,
+                  :country_daily_consumption,
                   :metric_sym
 
   def neighborhood
@@ -57,26 +57,26 @@ class UserElectricitySerializer < ActiveModel::Serializer
     object.url
   end
 
-  def household_total_savings
-    object.household_total_electricity_savings.to_f.round(2).to_s if !object.houses.empty?
+  def household_daily_consumption
+    object.household_daily_electricity_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def neighborhood_total_savings
-    object.neighborhood_total_electricity_savings.to_f.round(2).to_s if !object.houses.empty?
+  def neighborhood_daily_consumption
+    object.neighborhood_daily_electricity_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def city_total_savings
-    object.city_total_electricity_savings.to_f.round(2).to_s if !object.houses.empty?
+  def city_daily_consumption
+    object.city_daily_electricity_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def county_total_savings
-    object.county_total_electricity_savings.to_f.round(2).to_s if !object.houses.empty?
+  def county_daily_consumption
+    object.county_daily_electricity_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def region_total_savings
-    object.region_total_electricity_savings.to_f.round(2).to_s if !object.houses.empty?
+  def region_daily_consumption
+    object.region_daily_electricity_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def country_total_savings
-    object.country_total_electricity_savings.to_f.round(2).to_s if !object.houses.empty?
+  def country_daily_consumption
+    object.country_daily_electricity_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def total_savings
-    object.total_electricity_savings.round(2).to_s + " kwhs"
+  def avg_daily_consumption
+    object.avg_daily_electricity_consumption.round(2).to_s + " kwhs"
   end
   def rank
     object.user_electricity_ranking.rank

--- a/app/serializers/user_gas_serializer.rb
+++ b/app/serializers/user_gas_serializer.rb
@@ -1,16 +1,16 @@
 class UserGasSerializer < ActiveModel::Serializer
-  attributes :id, :total_savings, :first, :last, :email,
+  attributes :id, :avg_daily_consumption, :first, :last, :email,
                   :avatar_url, :house_ids,
                   :rank, :arrow, :last_updated,
-                  :personal_savings_to_date,
+                  :personal_usage_to_date,
                   :global_collective_savings,
                   :household, :neighborhood, :city, :county, :region, :country,
-                  :household_total_savings,
-                  :neighborhood_total_savings,
-                  :city_total_savings,
-                  :county_total_savings,
-                  :region_total_savings,
-                  :country_total_savings,
+                  :household_average_usage,
+                  :neighborhood_average_usage,
+                  :city_average_usage,
+                  :county_average_usage,
+                  :region_average_usage,
+                  :country_average_usage,
                   :metric_sym
 
   def neighborhood
@@ -33,8 +33,8 @@ class UserGasSerializer < ActiveModel::Serializer
     object.houses.map{|h| h.id} if object.houses.length > 0
   end
 
-  def personal_savings_to_date
-    object.total_gas_savings.to_f.round(2).to_s + " therms"
+  def personal_usage_to_date
+    object.total_therms_logged.to_f.round(2).to_s + " therms"
   end
 
   def global_collective_savings
@@ -61,26 +61,26 @@ class UserGasSerializer < ActiveModel::Serializer
     object.url
   end
 
-  def household_total_savings
-    object.household_total_gas_savings.to_f.round(2).to_s if !object.houses.empty?
+  def household_average_usage
+    object.household_daily_gas_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def neighborhood_total_savings
-    object.neighborhood_total_gas_savings.to_f.round(2).to_s if !object.houses.empty?
+  def neighborhood_average_usage
+    object.neighborhood_daily_gas_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def city_total_savings
-    object.city_total_gas_savings.to_f.round(2).to_s if !object.houses.empty?
+  def city_average_usage
+    object.city_daily_gas_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def county_total_savings 
-    object.county_total_gas_savings.to_f.round(2).to_s if !object.houses.empty?
+  def county_average_usage
+    object.county_daily_gas_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def region_total_savings
-    object.region_total_gas_savings.to_f.round(2).to_s if !object.houses.empty?
+  def region_average_usage
+    object.region_daily_gas_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def country_total_savings
-    object.country_total_gas_savings.to_f.round(2).to_s if !object.houses.empty?
+  def country_average_usage
+    object.country_daily_gas_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def total_savings
-    object.total_gas_savings.round(2).to_s + " therms"
+  def avg_daily_consumption
+    object.avg_daily_gas_consumption.round(2).to_s + " therms"
   end
   def rank
     object.user_gas_ranking.rank

--- a/app/serializers/user_gas_serializer.rb
+++ b/app/serializers/user_gas_serializer.rb
@@ -5,12 +5,12 @@ class UserGasSerializer < ActiveModel::Serializer
                   :personal_usage_to_date,
                   :global_collective_savings,
                   :household, :neighborhood, :city, :county, :region, :country,
-                  :household_average_usage,
-                  :neighborhood_average_usage,
-                  :city_average_usage,
-                  :county_average_usage,
-                  :region_average_usage,
-                  :country_average_usage,
+                  :household_daily_consumption,
+                  :neighborhood_daily_consumption,
+                  :city_daily_consumption,
+                  :county_daily_consumption,
+                  :region_daily_consumption,
+                  :country_daily_consumption,
                   :metric_sym
 
   def neighborhood
@@ -61,22 +61,22 @@ class UserGasSerializer < ActiveModel::Serializer
     object.url
   end
 
-  def household_average_usage
+  def household_daily_consumption
     object.household_daily_gas_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def neighborhood_average_usage
+  def neighborhood_daily_consumption
     object.neighborhood_daily_gas_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def city_average_usage
+  def city_daily_consumption
     object.city_daily_gas_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def county_average_usage
+  def county_daily_consumption
     object.county_daily_gas_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def region_average_usage
+  def region_daily_consumption
     object.region_daily_gas_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def country_average_usage
+  def country_daily_consumption
     object.country_daily_gas_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
   def avg_daily_consumption

--- a/app/serializers/user_water_serializer.rb
+++ b/app/serializers/user_water_serializer.rb
@@ -1,16 +1,16 @@
 class UserWaterSerializer < ActiveModel::Serializer
-  attributes :id, :total_savings, :first, :last, :email,
+  attributes :id, :avg_daily_consumption, :first, :last, :email,
                   :avatar_url, :house_ids,
                   :rank, :arrow, :last_updated,
                   :personal_savings_to_date,
                   :global_collective_savings,
                   :household, :neighborhood, :city, :county, :region, :country,
-                  :household_total_savings,
-                  :neighborhood_total_savings,
-                  :city_total_savings,
-                  :county_total_savings,
-                  :region_total_savings,
-                  :country_total_savings,
+                  :household_daily_consumption,
+                  :neighborhood_daily_consumption,
+                  :city_daily_consumption,
+                  :county_daily_consumption,
+                  :region_daily_consumption,
+                  :country_daily_consumption,
                   :metric_sym
 
   def neighborhood
@@ -57,28 +57,28 @@ class UserWaterSerializer < ActiveModel::Serializer
     object.url
   end
 
-  def household_total_savings
-    object.household_total_water_savings.to_f.round(2).to_s if !object.houses.empty?
+  def household_daily_consumption
+    object.household_daily_water_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def neighborhood_total_savings
-    object.neighborhood_total_water_savings.to_f.round(2).to_s if !object.houses.empty?
+  def neighborhood_daily_consumption
+    object.neighborhood_daily_water_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
-  def city_total_savings
-    object.city_total_water_savings.to_f.round(2).to_s if !object.houses.empty?
-  end
-
-  def county_total_savings
-    object.country_total_water_savings.to_f.round(2).to_s if !object.houses.empty?
-  end
-  def region_total_savings
-    object.region_total_water_savings.to_f.round(2).to_s if !object.houses.empty?
-  end
-  def country_total_savings
-    object.country_total_water_savings.to_f.round(2).to_s if !object.houses.empty?
+  def city_daily_consumption
+    object.city_daily_water_consumption.to_f.round(2).to_s if !object.houses.empty?
   end
 
-  def total_savings
-    object.total_water_savings.round(2).to_s + " gals"
+  def county_daily_consumption
+    object.country_daily_water_consumption.to_f.round(2).to_s if !object.houses.empty?
+  end
+  def region_daily_consumption
+    object.region_daily_water_consumption.to_f.round(2).to_s if !object.houses.empty?
+  end
+  def country_daily_consumption
+    object.country_daily_water_consumption.to_f.round(2).to_s if !object.houses.empty?
+  end
+
+  def avg_daily_consumption
+    object.avg_daily_water_consumption.round(2).to_s + " gals"
   end
 
   def rank


### PR DESCRIPTION
Removes savings data and replaces with average_daily_consumption of any given resource on dash and ranked pages; leaves savings for userboards (as averages are not stored on users themselves, and would require a serializer change)