### PR TITLE
House no residents

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -6,6 +6,9 @@ class AddressesController < ApplicationController
     @address = Address.new(safe_params)
     @address.zipcode_id = zipcode.id
     if @address.save
+      user = User.find(params[:user_id])
+      House.create(address_id: @address.id, no_residents: 1)
+      user.houses << House.last
       render json: @address, status: 202
     elsif !@address.save && @address.errors.messages[:address_line1][0] == 'has already been taken'
       city_id = @address.city_id
@@ -16,6 +19,9 @@ class AddressesController < ApplicationController
         error = "House already exists"
         render :json => {:errors => error, :house => @house.id}, status: 401
       else
+        user = User.find(params[:user_id])
+        House.create(address_id: old_address.id, no_residents: 1)
+        user.houses << House.last
         render json: old_address, status: 202
       end
     else

--- a/app/controllers/api/v1/addresses_controller.rb
+++ b/app/controllers/api/v1/addresses_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::AddressesController < ApplicationController
 
   def show
     if Address.exists?(params[:id])
-      render json: Address.find(params[:id]), serializer: AddressBasicSerializer
+      render json: Address.find(params[:id]), serializer: AddressSerializer
     else
       render json: {error: "Address does not exist"}, status: 404
     end

--- a/app/models/house.rb
+++ b/app/models/house.rb
@@ -3,9 +3,6 @@ class House < ApplicationRecord
 
   belongs_to :address
 
-  validates_presence_of :total_sq_ft
-  validates_presence_of :no_residents
-
   validates :address_id, presence: true, uniqueness: true
 
   has_many :user_houses, dependent: :destroy
@@ -24,6 +21,5 @@ class House < ApplicationRecord
   def bills
     self.electric_bills
   end
-
-
+  
 end

--- a/app/models/user_house.rb
+++ b/app/models/user_house.rb
@@ -4,7 +4,7 @@ class UserHouse < ApplicationRecord
 
   validates_uniqueness_of :user_id, :scope => :house_id
 
-  # before_create :update_house_no_residents_add
+  before_create :update_house_no_residents_add
   before_destroy :update_house_no_residents_less
 
   def update_house_no_residents_add

--- a/app/serializers/address_basic_serializer.rb
+++ b/app/serializers/address_basic_serializer.rb
@@ -1,5 +1,5 @@
 class AddressBasicSerializer < ActiveModel::Serializer
-  attributes :id, :full_address
+  attributes :id, :full_address, :house
 
   def full_address
     object.address_line1 + ' ' + object.address_line2.to_s + ' ' + object.city.name +

--- a/app/serializers/address_serializer.rb
+++ b/app/serializers/address_serializer.rb
@@ -1,4 +1,4 @@
-class AddressBasicSerializer < ActiveModel::Serializer
+class AddressSerializer < ActiveModel::Serializer
   attributes :id, :full_address, :house
 
   def full_address

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -746,14 +746,11 @@ country.update_data
 state.update_data
 
 User.all.each{|u|
-   # hId = u.household.id
-   # UserElectricityQuestion.create(user_id: u.id, house_id: hId)
-   # UserWaterQuestion.create(user_id: u.id, house_id: hId)
-   # UserGasQuestion.create(user_id: u.id, house_id: hId)
+   hId = u.household.id
    u.email_activate
    u.privacy_policy = true
    u.set_default_ranks
-   u.set_all_questions
+   u.set_all_questions(hId)
    u.save
  }
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -752,7 +752,9 @@ User.all.each{|u|
    # UserGasQuestion.create(user_id: u.id, house_id: hId)
    u.email_activate
    u.privacy_policy = true
-   # u.set_default_ranks
+   u.set_default_ranks
+   u.set_all_questions
+   u.save
  }
 
 County.all.each do |c|


### PR DESCRIPTION
opts to leave no_residents on the house model for future play; merely changes the backend so that signup can be more efficient and skips over the 'AddHousehold' page.  Change address serializer.